### PR TITLE
fix: always render description block

### DIFF
--- a/templates/challenge.html
+++ b/templates/challenge.html
@@ -43,9 +43,7 @@
               </div>
             {% endif %}
 
-            {% if challenge.html %}
-              <span class="challenge-desc">{% block description %}{{ challenge.html }}{% endblock %}</span>
-            {% endif %}
+            <span class="challenge-desc">{% block description %}{{ challenge.html }}{% endblock %}</span>
 
             {% if challenge.connection_info %}
               <div class="mb-2">


### PR DESCRIPTION
Even if markdown is not present, we should render the description block as it's an anchor point for specific plugins