### PR TITLE
Add build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,11 @@
-name: prettier
+name: build
 
-on: [ pull_request ]
+on:
+  push:
+    branches: main
 
 jobs:
-  lint:
+  static:
     runs-on: ubuntu-latest
 
     steps:
@@ -17,5 +19,12 @@ jobs:
           node-version: '16.x'
       - name: Install dependencies
         run: yarn --frozen-lockfile
-      - name: Lint with prettier
-        run: yarn lint
+      - name: Format
+        run: yarn format
+      - name: Build
+        run: yarn build
+      - name: Push built files
+        uses: EndBug/add-and-commit@v9
+        with:
+          default_author: github_actions
+          message: "chore: yarn build"

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -32,4 +32,6 @@ CTFd.init(window.init);
   eventToasts();
 })();
 
+console.log("test");
+
 export default CTFd;

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -32,6 +32,4 @@ CTFd.init(window.init);
   eventToasts();
 })();
 
-console.log("test");
-
 export default CTFd;


### PR DESCRIPTION
This adds a build action, which will be executed after the PR is merged.

I originally wanted to implement this in the PR step, but that rebuilds after each push and required the author to pull back the built files which I imagine would get annoying. 

The way this is implemented currently, we run lint on PRs (again, not format to avoid having to pull), and after the PR will get merged the build step will get executed and commit built files to the main branch.