### PR TITLE
Remove row class from score-graph element

### DIFF
--- a/templates/scoreboard.html
+++ b/templates/scoreboard.html
@@ -9,7 +9,7 @@
   <div class="container">
     {% include "components/errors.html" %}
 
-    <div id="score-graph" class="row d-flex align-items-center" x-data="ScoreboardDetail" x-ref="scoregraph">
+    <div id="score-graph" class="d-flex align-items-center" x-data="ScoreboardDetail" x-ref="scoregraph">
       <div class="col-md-12 text-center">
         <i class="fas fa-circle-notch fa-spin fa-3x fa-fw spinner"></i>
       </div>


### PR DESCRIPTION
On `/scoreboard`, the main scoreboard graph has an issue with the width of the tooltip that displays when you hover over a team, where the tooltip is 100% the width of the page.

!["Incorrect width tooltip in main scoreboard graph"](https://user-images.githubusercontent.com/35712968/190877342-76f4b6b7-f891-4099-a546-9f6ef681d5a5.png)

This issue is because there is a `row` class, which in Bootstrap sets all child elements to use a width of 100%. Since the tooltip is positioned absolutely, it uses the width of the next highest positioned element, which in this case is the document body. The easiest fix is to remove the `row` class, which is what the score graphs on the individual team/user profiles already do.

In individual team/user scoreboard graphs, the `row` class is not present, which creates a valid width tooltip:

![image](https://user-images.githubusercontent.com/35712968/190877453-e5b4fc20-1937-4a91-a856-1dc03dd19cec.png)
