### PR TITLE
Add missing href on challenge nav-tabs

### DIFF
--- a/templates/challenge.html
+++ b/templates/challenge.html
@@ -7,14 +7,14 @@
 
         <ul class="nav nav-tabs">
           <li class="nav-item">
-            <a class="nav-link active" data-bs-target="#challenge" @click="showChallenge()">
+            <a class="nav-link active" href="#" data-bs-target="#challenge" @click="showChallenge()">
               {% trans %}Challenge{% endtrans %}
             </a>
           </li>
 
           {% block solves %}
             <li class="nav-item">
-              <a class="nav-link challenge-solves" data-bs-target="#solves" @click="showSolves()">
+              <a class="nav-link challenge-solves" href="#" data-bs-target="#solves" @click="showSolves()">
                 {% if solves != None %}
                   {{ ngettext("%(num)d Solve", "%(num)d Solves", solves) }}
                 {% endif %}


### PR DESCRIPTION
As shown on Bootstrap official documentation (https://getbootstrap.com/docs/5.0/components/navs-tabs/), tabs anchor elements should have a `href` attribute. This fixes some accessibility issues with keyboard navigation, as these tabs are now recognized as links.
