### PR TITLE
Fix social share extra div when disabled

### DIFF
--- a/templates/challenge.html
+++ b/templates/challenge.html
@@ -187,8 +187,8 @@
                             <i class="fa-brands fa-linkedin-in"></i>
                           </a>
                         </div>
-                        {% endif %}
                       </div>
+                      {% endif %}
                     </div>
                   </div>
                 </template>


### PR DESCRIPTION
When social share buttons are disabled, an extra `</div>` is introduced in `challenge.html`.