### PR TITLE
Do not scroll to top when clicking challenge tabs

### DIFF
--- a/templates/challenge.html
+++ b/templates/challenge.html
@@ -7,18 +7,18 @@
 
         <ul class="nav nav-tabs">
           <li class="nav-item">
-            <a class="nav-link active" href="#" data-bs-target="#challenge" @click="showChallenge()">
+            <button class="nav-link active" data-bs-target="#challenge" @click="showChallenge()">
               {% trans %}Challenge{% endtrans %}
-            </a>
+            </button>
           </li>
 
           {% block solves %}
             <li class="nav-item">
-              <a class="nav-link challenge-solves" href="#" data-bs-target="#solves" @click="showSolves()">
+              <button class="nav-link challenge-solves" data-bs-target="#solves" @click="showSolves()">
                 {% if solves != None %}
                   {{ ngettext("%(num)d Solve", "%(num)d Solves", solves) }}
                 {% endif %}
-              </a>
+              </button>
             </li>
           {% endblock %}
         </ul>


### PR DESCRIPTION
f6b731d748c4433df9e1f40b298c936bb921a4b7 introduced a `href` attribute on the anchors used as Bootstrap tabs.
As there is nothing in JS preventing the default click action, this causes this page to scroll to top (sorry).

A simple fix would be to use `@onclick.prevent` with AlpineJS, but a cleaner fix is to use button elements. Using anchors as tabs does not really make sense here as users don't need to drag&drop the anchor.