### PR TITLE
notifications.html: use bg-body

### DIFF
--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -15,7 +15,7 @@
 		</h2>
 		{% endif %}
 		{% for notification in notifications %}
-		<div class="card bg-light mb-4">
+		<div class="card bg-body mb-4">
 			<div class="card-body">
 				<h3 class="card-title">{{ notification.title }}</h3>
 				<blockquote class="blockquote mb-0">

--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -15,7 +15,7 @@
 		</h2>
 		{% endif %}
 		{% for notification in notifications %}
-		<div class="card bg-body mb-4">
+		<div class="card bg-body-tertiary mb-4">
 			<div class="card-body">
 				<h3 class="card-title">{{ notification.title }}</h3>
 				<blockquote class="blockquote mb-0">


### PR DESCRIPTION
When using core-beta in dark mode (https://getbootstrap.com/docs/5.3/customize/color-modes/#dark-mode), the notifications page is unreadable.

Before:
![swappy-20240412_141914](https://github.com/CTFd/core-beta/assets/2663216/7faad994-988b-4554-a9f7-c77dcd9ac188)

After:
![swappy-20240412_141849](https://github.com/CTFd/core-beta/assets/2663216/14351043-cb80-49e2-ac13-5a5a8f515ebe)
