### PR TITLE
Mark more strings as translatable in navbar, register and user search templates

### DIFF
--- a/templates/components/navbar.html
+++ b/templates/components/navbar.html
@@ -69,7 +69,7 @@
           {% if is_admin() %}
             <li class="nav-item">
               <a class="nav-link" href="{{ url_for('admin.view') }}">
-                <span data-bs-toggle="tooltip" data-bs-placement="bottom" title="Admin Panel">
+                <span data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans %}Admin Panel{% endtrans %}">
                     <i class="fas fa-wrench d-none d-md-inline d-lg-none"></i>
                 </span>
                 <span class="d-sm-inline d-md-none d-lg-inline">
@@ -82,7 +82,7 @@
 
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('views.notifications') }}">
-              <span data-bs-toggle="tooltip" data-bs-placement="bottom" title="Notifications">
+              <span data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans %}Notifications{% endtrans %}">
                 <i class="fas fa-bell d-none d-md-inline d-lg-none"></i>
               </span>
               <span class="d-sm-inline d-md-none d-lg-inline">
@@ -96,7 +96,7 @@
           {% if Configs.user_mode == "teams" %}
             <li class="nav-item">
               <a class="nav-link" href="{{ url_for('teams.private') }}">
-                <span data-bs-toggle="tooltip" data-bs-placement="bottom" title="Team">
+                <span data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans %}Team{% endtrans %}">
                   <i class="fas fa-users d-none d-md-inline d-lg-none"></i>
                 </span>
                 <span class="d-sm-inline d-md-none d-lg-inline">
@@ -109,7 +109,7 @@
 
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('users.private') }}">
-              <span data-bs-toggle="tooltip" data-bs-placement="bottom" title="Profile">
+              <span data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans %}Profile{% endtrans %}">
                 <i class="fas fa-user-circle d-none d-md-inline d-lg-none"></i>
               </span>
               <span class="d-sm-inline d-md-none d-lg-inline">
@@ -121,7 +121,7 @@
 
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('views.settings') }}">
-              <span data-bs-toggle="tooltip" data-bs-placement="bottom" title="Settings">
+              <span data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans %}Settings{% endtrans %}">
                 <i class="fas fa-cogs d-none d-md-inline d-lg-none"></i>
               </span>
               <span class="d-sm-inline d-md-none d-lg-inline">
@@ -133,7 +133,7 @@
 
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('auth.logout') }}">
-              <span data-bs-toggle="tooltip" data-bs-placement="bottom" title="Logout">
+              <span data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans %}Logout{% endtrans %}">
                 <i class="fas fa-sign-out-alt d-none d-md-inline d-lg-none"></i>
               </span>
               <span class="d-sm-inline d-md-none d-lg-inline">
@@ -148,7 +148,7 @@
           {% if registration_visible() %}
             <li class="nav-item">
               <a class="nav-link" href="{{ url_for('auth.register') }}">
-                <span data-bs-toggle="tooltip" data-bs-placement="bottom" title="Register">
+                <span data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans %}Register{% endtrans %}">
                   <i class="fas fa-user-plus d-none d-md-inline d-lg-none"></i>
                 </span>
                 <span class="d-sm-inline d-md-none d-lg-inline">
@@ -161,7 +161,7 @@
 
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('auth.login') }}">
-              <span data-bs-toggle="tooltip" data-bs-placement="bottom" title="Login">
+              <span data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans %}Login{% endtrans %}">
                 <i class="fas fa-sign-in-alt d-none d-md-inline d-lg-none"></i>
               </span>
               <span class="d-sm-inline d-md-none d-lg-inline">

--- a/templates/register.html
+++ b/templates/register.html
@@ -66,9 +66,11 @@
               <div class="row pt-3">
                 <div class="col-md-12 text-center">
                   <small class="text-muted text-center">
+                    {% trans trimmed privacy_link=Configs.privacy_link, tos_link=Configs.tos_link %}
                     By registering, you agree to the
-                    <a href="{{ Configs.privacy_link }}" rel="noopener" target="_blank">privacy policy</a>
-                    and <a href="{{ Configs.tos_link }}" rel="noopener" target="_blank">terms of service</a>
+                    <a href="{{ privacy_link }}" target="_blank">privacy policy</a>
+                    and <a href="{{ tos_link }}" target="_blank">terms of service</a>
+                    {% endtrans %}
                   </small>
                 </div>
               </div>

--- a/templates/users/users.html
+++ b/templates/users/users.html
@@ -11,10 +11,10 @@
       <div class="col-md-12">
         {% if q and field %}
           <h5 class="text-muted text-center">
-            Searching for users with <strong>{{ field }}</strong> matching <strong>{{ q }}</strong>
+            {% trans %}Searching for users with <strong>{{ field }}</strong> matching <strong>{{ q }}</strong>{% endtrans %}
           </h5>
           <h6 class="text-muted text-center pb-3">
-            Page {{ users.page }} of {{ users.total }} results
+            {% trans page=users.page, total=users.total %}Page {{ page }} of {{ total }} results{% endtrans %}
           </h6>
         {% endif %}
 


### PR DESCRIPTION
While translating CTFd for a French CTF challenge, I notice some strings missing from the translation.

These patches are used in production here: https://france-cybersecurity-challenge.fr/