### PR TITLE
Fix issue where CTFd JS could not be used because an entrypoint dependency was missing

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -57,7 +57,7 @@
 {% include "components/notifications.html" %}
 
 {% block scripts %}
-  {{ Assets.js("assets/js/index.js") }}
+  {{ Assets.js("assets/js/page.js") }}
 {% endblock %}
 
 {{ Plugins.scripts }}


### PR DESCRIPTION
* Fix issue where CTFd JS could not be used because an entrypoint dependency was missing

Seperately I'm not sure if this should be called index.js. I think maybe main.js makes more sense or even init.js.

I also considered setting the default extends template to be page.html instead of base.html or adding in page.js as the entrypoint script. I decided that setting page.js as the default entrypoint made more sense as less changes were required and all pages get a safer default. 