### PR TITLE
Autocomplete attribute on login, register and password_reset

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -1,53 +1,55 @@
-{% extends "base.html" %} {% block content %}
-<div class="jumbotron">
+{% extends "base.html" %}
+
+{% block content %}
+  <div class="jumbotron">
     <div class="container">
-        <h1>{% trans %}Login{% endtrans %}</h1>
+      <h1>
+        {% trans %}Login{% endtrans %}
+      </h1>
     </div>
-</div>
+  </div>
 
-<div class="container">
+  <div class="container">
     <div class="row">
-        <div class="col-md-8 col offset-md-2 col-lg-6 offset-lg-3">
-            {% include "components/errors.html" %} {% if integrations.mlc() %}
-            <a
-                class="btn btn-secondary btn-lg btn-block w-100"
-                href="{{ url_for('auth.oauth_login') }}"
-            >
-                Login with Major League Cyber
-            </a>
+      <div class="col-md-8 col offset-md-2 col-lg-6 offset-lg-3">
+        {% include "components/errors.html" %}
 
-            <hr />
-            {% endif %} {% with form = Forms.auth.LoginForm() %}
-            <form method="post" accept-charset="utf-8" autocomplete="off">
-                <div class="mb-3">
-                    <b>{{ form.name.label(class="form-label") }}</b>
-                    {{ form.name(class="form-control", value=name, autocomplete="username") }}
-                </div>
+        {% if integrations.mlc() %}
+          <a class="btn btn-secondary btn-lg btn-block w-100" href="{{ url_for('auth.oauth_login') }}">
+            Login with Major League Cyber
+          </a>
 
-                <div class="mb-3">
-                    <b>{{ form.password.label(class="form-label") }}</b>
-                    {{ form.password(class="form-control", value=password, autocomplete="current-password") }}
-                </div>
+          <hr>
+        {% endif %}
 
-                <div class="row pt-3">
-                    <div class="col-6 col-md-8">
-                        <a
-                            class="align-middle"
-                            href="{{ url_for('auth.reset_password') }}"
-                        >
-                            {% trans %}Forgot your password?{% endtrans %}
-                        </a>
-                    </div>
+        {% with form = Forms.auth.LoginForm() %}
+          <form method="post" accept-charset="utf-8" autocomplete="off">
+            <div class="mb-3">
+              <b>{{ form.name.label(class="form-label") }}</b>
+              {{ form.name(class="form-control", value=name, autocomplete="username email") }}
+            </div>
 
-                    <div class="col-6 col-md-4">
-                        {{ form.submit(class="btn btn-block btn-primary w-100") }}
-                    </div>
-                </div>
+            <div class="mb-3">
+              <b>{{ form.password.label(class="form-label") }}</b>
+              {{ form.password(class="form-control", value=password, autocomplete="current-password") }}
+            </div>
 
-                {{ form.nonce() }}
-            </form>
-            {% endwith %}
-        </div>
+            <div class="row pt-3">
+              <div class="col-6 col-md-8">
+                <a class="align-middle" href="{{ url_for('auth.reset_password') }}">
+                  {% trans %}Forgot your password?{% endtrans %}
+                </a>
+              </div>
+
+              <div class="col-6 col-md-4">
+                {{ form.submit(class="btn btn-block btn-primary w-100") }}
+              </div>
+            </div>
+
+            {{ form.nonce() }}
+          </form>
+        {% endwith %}
+      </div>
     </div>
-</div>
+  </div>
 {% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -23,7 +23,7 @@
         {% endif %}
 
         {% with form = Forms.auth.LoginForm() %}
-          <form method="post" accept-charset="utf-8" autocomplete="off">
+          <form method="post" accept-charset="utf-8">
             <div class="mb-3">
               <b>{{ form.name.label(class="form-label") }}</b>
               {{ form.name(class="form-control", value=name, autocomplete="username email") }}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,55 +1,53 @@
-{% extends "base.html" %}
-
-{% block content %}
-  <div class="jumbotron">
+{% extends "base.html" %} {% block content %}
+<div class="jumbotron">
     <div class="container">
-      <h1>
-        {% trans %}Login{% endtrans %}
-      </h1>
+        <h1>{% trans %}Login{% endtrans %}</h1>
     </div>
-  </div>
+</div>
 
-  <div class="container">
+<div class="container">
     <div class="row">
-      <div class="col-md-8 col offset-md-2 col-lg-6 offset-lg-3">
-        {% include "components/errors.html" %}
+        <div class="col-md-8 col offset-md-2 col-lg-6 offset-lg-3">
+            {% include "components/errors.html" %} {% if integrations.mlc() %}
+            <a
+                class="btn btn-secondary btn-lg btn-block w-100"
+                href="{{ url_for('auth.oauth_login') }}"
+            >
+                Login with Major League Cyber
+            </a>
 
-        {% if integrations.mlc() %}
-          <a class="btn btn-secondary btn-lg btn-block w-100" href="{{ url_for('auth.oauth_login') }}">
-            Login with Major League Cyber
-          </a>
+            <hr />
+            {% endif %} {% with form = Forms.auth.LoginForm() %}
+            <form method="post" accept-charset="utf-8" autocomplete="off">
+                <div class="mb-3">
+                    <b>{{ form.name.label(class="form-label") }}</b>
+                    {{ form.name(class="form-control", value=name, autocomplete="username") }}
+                </div>
 
-          <hr>
-        {% endif %}
+                <div class="mb-3">
+                    <b>{{ form.password.label(class="form-label") }}</b>
+                    {{ form.password(class="form-control", value=password, autocomplete="current-password") }}
+                </div>
 
-        {% with form = Forms.auth.LoginForm() %}
-          <form method="post" accept-charset="utf-8" autocomplete="off">
-            <div class="mb-3">
-              <b>{{ form.name.label(class="form-label") }}</b>
-              {{ form.name(class="form-control", value=name) }}
-            </div>
+                <div class="row pt-3">
+                    <div class="col-6 col-md-8">
+                        <a
+                            class="align-middle"
+                            href="{{ url_for('auth.reset_password') }}"
+                        >
+                            {% trans %}Forgot your password?{% endtrans %}
+                        </a>
+                    </div>
 
-            <div class="mb-3">
-              <b>{{ form.password.label(class="form-label") }}</b>
-              {{ form.password(class="form-control", value=password) }}
-            </div>
+                    <div class="col-6 col-md-4">
+                        {{ form.submit(class="btn btn-block btn-primary w-100") }}
+                    </div>
+                </div>
 
-            <div class="row pt-3">
-              <div class="col-6 col-md-8">
-                <a class="align-middle" href="{{ url_for('auth.reset_password') }}">
-                  {% trans %}Forgot your password?{% endtrans %}
-                </a>
-              </div>
-
-              <div class="col-6 col-md-4">
-                {{ form.submit(class="btn btn-block btn-primary w-100") }}
-              </div>
-            </div>
-
-            {{ form.nonce() }}
-          </form>
-        {% endwith %}
-      </div>
+                {{ form.nonce() }}
+            </form>
+            {% endwith %}
+        </div>
     </div>
-  </div>
+</div>
 {% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -26,7 +26,7 @@
 
           {% from "macros/forms.html" import render_extra_fields %}
 
-          <form method="post" accept-charset="utf-8" autocomplete="off" role="form">
+          <form method="post" accept-charset="utf-8" role="form">
 
             <div class="mb-3">
               <b>{{ form.name.label(class="form-label") }}</b>

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,80 +1,83 @@
-{% extends "base.html" %} {% block content %}
-<div class="jumbotron">
+{% extends "base.html" %}
+
+{% block content %}
+  <div class="jumbotron">
     <div class="container">
-        <h1>{% trans %}Register{% endtrans %}</h1>
+      <h1>
+        {% trans %}Register{% endtrans %}
+      </h1>
     </div>
-</div>
+  </div>
 
-<div class="container">
+  <div class="container">
     <div class="row">
-        <div class="col-md-6 offset-md-3">
-            {% include "components/errors.html" %} {% if integrations.mlc() %}
-            <a
-                class="btn btn-secondary btn-lg btn-block w-100"
-                href="{{ url_for('auth.oauth_login') }}"
-            >
-                Login with Major League Cyber
-            </a>
+      <div class="col-md-6 offset-md-3">
+        {% include "components/errors.html" %}
 
-            <hr />
-            {% endif %} {% with form = Forms.auth.RegistrationForm() %} {% from
-            "macros/forms.html" import render_extra_fields %}
+        {% if integrations.mlc() %}
+          <a class="btn btn-secondary btn-lg btn-block w-100" href="{{ url_for('auth.oauth_login') }}">
+            Login with Major League Cyber
+          </a>
 
-            <form method="post" accept-charset="utf-8" autocomplete="off" role="form">
-                <div class="mb-3">
-                    <b>{{ form.name.label(class="form-label") }}</b>
-                    {{ form.name(class="form-control", value=name, autocomplete="username") }}
-                    <small class="form-text text-muted">
-                        {% trans %}Your username on the site{% endtrans %}
-                    </small>
+          <hr>
+        {% endif %}
+
+        {% with form = Forms.auth.RegistrationForm() %}
+
+          {% from "macros/forms.html" import render_extra_fields %}
+
+          <form method="post" accept-charset="utf-8" autocomplete="off" role="form">
+
+            <div class="mb-3">
+              <b>{{ form.name.label(class="form-label") }}</b>
+              {{ form.name(class="form-control", value=name, autocomplete="username") }}
+              <small class="form-text text-muted">
+                {% trans %}Your username on the site{% endtrans %}
+              </small>
+            </div>
+
+            <div class="mb-3">
+              <b>{{ form.email.label(class="form-label") }}</b>
+              {{ form.email(class="form-control", value=email, autocomplete="email") }}
+              <small class="form-text text-muted">
+                {% trans %}Never shown to the public{% endtrans %}
+              </small>
+            </div>
+
+            <div class="mb-3">
+              <b>{{ form.password.label(class="form-label") }}</b>
+              {{ form.password(class="form-control", value=password, autocomplete="new-password") }}
+              <small class="form-text text-muted">
+                {% trans %}Password used to log into your account{% endtrans %}
+              </small>
+            </div>
+
+            {{ form.nonce() }}
+
+            {{ render_extra_fields(form.extra) }}
+
+            <div class="row pt-3">
+              <div class="col-6 col-md-4 offset-6 offset-md-8">
+                {{ form.submit(class="btn btn-block btn-primary w-100") }}
+              </div>
+            </div>
+
+            {% if Configs.tos_or_privacy %}
+              <div class="row pt-3">
+                <div class="col-md-12 text-center">
+                  <small class="text-muted text-center">
+                    {% trans trimmed privacy_link=Configs.privacy_link, tos_link=Configs.tos_link %}
+                    By registering, you agree to the
+                    <a href="{{ privacy_link }}" target="_blank">privacy policy</a>
+                    and <a href="{{ tos_link }}" target="_blank">terms of service</a>
+                    {% endtrans %}
+                  </small>
                 </div>
-
-                <div class="mb-3">
-                    <b>{{ form.email.label(class="form-label") }}</b>
-                    {{ form.email(class="form-control", value=email, autocomplete="email") }}
-                    <small class="form-text text-muted">
-                        {% trans %}Never shown to the public{% endtrans %}
-                    </small>
-                </div>
-
-                <div class="mb-3">
-                    <b>{{ form.password.label(class="form-label") }}</b>
-                    {{ form.password(class="form-control", value=password, autocomplete="new-password") }}
-                    <small class="form-text text-muted">
-                        {% trans %}Password used to log into your account{% endtrans %}
-                    </small>
-                </div>
-
-                {{ form.nonce() }} {{ render_extra_fields(form.extra) }}
-
-                <div class="row pt-3">
-                    <div class="col-6 col-md-4 offset-6 offset-md-8">
-                        {{ form.submit(class="btn btn-block btn-primary w-100") }}
-                    </div>
-                </div>
-
-                {% if Configs.tos_or_privacy %}
-                <div class="row pt-3">
-                    <div class="col-md-12 text-center">
-                        <small class="text-muted text-center">
-                            {% trans trimmed privacy_link=Configs.privacy_link,
-                            tos_link=Configs.tos_link %} By registering, you agree to
-                            the
-                            <a href="{{ privacy_link }}" target="_blank"
-                                >privacy policy</a
-                            >
-                            and
-                            <a href="{{ tos_link }}" target="_blank"
-                                >terms of service</a
-                            >
-                            {% endtrans %}
-                        </small>
-                    </div>
-                </div>
-                {% endif %}
-            </form>
-            {% endwith %}
-        </div>
+              </div>
+            {% endif %}
+          </form>
+        {% endwith %}
+      </div>
     </div>
-</div>
+  </div>
 {% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,83 +1,80 @@
-{% extends "base.html" %}
-
-{% block content %}
-  <div class="jumbotron">
+{% extends "base.html" %} {% block content %}
+<div class="jumbotron">
     <div class="container">
-      <h1>
-        {% trans %}Register{% endtrans %}
-      </h1>
+        <h1>{% trans %}Register{% endtrans %}</h1>
     </div>
-  </div>
+</div>
 
-  <div class="container">
+<div class="container">
     <div class="row">
-      <div class="col-md-6 offset-md-3">
-        {% include "components/errors.html" %}
+        <div class="col-md-6 offset-md-3">
+            {% include "components/errors.html" %} {% if integrations.mlc() %}
+            <a
+                class="btn btn-secondary btn-lg btn-block w-100"
+                href="{{ url_for('auth.oauth_login') }}"
+            >
+                Login with Major League Cyber
+            </a>
 
-        {% if integrations.mlc() %}
-          <a class="btn btn-secondary btn-lg btn-block w-100" href="{{ url_for('auth.oauth_login') }}">
-            Login with Major League Cyber
-          </a>
+            <hr />
+            {% endif %} {% with form = Forms.auth.RegistrationForm() %} {% from
+            "macros/forms.html" import render_extra_fields %}
 
-          <hr>
-        {% endif %}
-
-        {% with form = Forms.auth.RegistrationForm() %}
-
-          {% from "macros/forms.html" import render_extra_fields %}
-
-          <form method="post" accept-charset="utf-8" autocomplete="off" role="form">
-
-            <div class="mb-3">
-              <b>{{ form.name.label(class="form-label") }}</b>
-              {{ form.name(class="form-control", value=name) }}
-              <small class="form-text text-muted">
-                {% trans %}Your username on the site{% endtrans %}
-              </small>
-            </div>
-
-            <div class="mb-3">
-              <b>{{ form.email.label(class="form-label") }}</b>
-              {{ form.email(class="form-control", value=email) }}
-              <small class="form-text text-muted">
-                {% trans %}Never shown to the public{% endtrans %}
-              </small>
-            </div>
-
-            <div class="mb-3">
-              <b>{{ form.password.label(class="form-label") }}</b>
-              {{ form.password(class="form-control", value=password) }}
-              <small class="form-text text-muted">
-                {% trans %}Password used to log into your account{% endtrans %}
-              </small>
-            </div>
-
-            {{ form.nonce() }}
-
-            {{ render_extra_fields(form.extra) }}
-
-            <div class="row pt-3">
-              <div class="col-6 col-md-4 offset-6 offset-md-8">
-                {{ form.submit(class="btn btn-block btn-primary w-100") }}
-              </div>
-            </div>
-
-            {% if Configs.tos_or_privacy %}
-              <div class="row pt-3">
-                <div class="col-md-12 text-center">
-                  <small class="text-muted text-center">
-                    {% trans trimmed privacy_link=Configs.privacy_link, tos_link=Configs.tos_link %}
-                    By registering, you agree to the
-                    <a href="{{ privacy_link }}" target="_blank">privacy policy</a>
-                    and <a href="{{ tos_link }}" target="_blank">terms of service</a>
-                    {% endtrans %}
-                  </small>
+            <form method="post" accept-charset="utf-8" autocomplete="off" role="form">
+                <div class="mb-3">
+                    <b>{{ form.name.label(class="form-label") }}</b>
+                    {{ form.name(class="form-control", value=name, autocomplete="username") }}
+                    <small class="form-text text-muted">
+                        {% trans %}Your username on the site{% endtrans %}
+                    </small>
                 </div>
-              </div>
-            {% endif %}
-          </form>
-        {% endwith %}
-      </div>
+
+                <div class="mb-3">
+                    <b>{{ form.email.label(class="form-label") }}</b>
+                    {{ form.email(class="form-control", value=email, autocomplete="email") }}
+                    <small class="form-text text-muted">
+                        {% trans %}Never shown to the public{% endtrans %}
+                    </small>
+                </div>
+
+                <div class="mb-3">
+                    <b>{{ form.password.label(class="form-label") }}</b>
+                    {{ form.password(class="form-control", value=password, autocomplete="new-password") }}
+                    <small class="form-text text-muted">
+                        {% trans %}Password used to log into your account{% endtrans %}
+                    </small>
+                </div>
+
+                {{ form.nonce() }} {{ render_extra_fields(form.extra) }}
+
+                <div class="row pt-3">
+                    <div class="col-6 col-md-4 offset-6 offset-md-8">
+                        {{ form.submit(class="btn btn-block btn-primary w-100") }}
+                    </div>
+                </div>
+
+                {% if Configs.tos_or_privacy %}
+                <div class="row pt-3">
+                    <div class="col-md-12 text-center">
+                        <small class="text-muted text-center">
+                            {% trans trimmed privacy_link=Configs.privacy_link,
+                            tos_link=Configs.tos_link %} By registering, you agree to
+                            the
+                            <a href="{{ privacy_link }}" target="_blank"
+                                >privacy policy</a
+                            >
+                            and
+                            <a href="{{ tos_link }}" target="_blank"
+                                >terms of service</a
+                            >
+                            {% endtrans %}
+                        </small>
+                    </div>
+                </div>
+                {% endif %}
+            </form>
+            {% endwith %}
+        </div>
     </div>
-  </div>
+</div>
 {% endblock %}

--- a/templates/reset_password.html
+++ b/templates/reset_password.html
@@ -23,7 +23,7 @@
 
               <div class="mb-3">
                 {{ form.password.label(class="form-label") }}
-                {{ form.password(class="form-control") }}
+                {{ form.password(class="form-control", autocomplete="new-password") }}
               </div>
 
               <div class="row pt-3">

--- a/templates/reset_password.html
+++ b/templates/reset_password.html
@@ -16,7 +16,7 @@
 
         {% if mode == "set" %}
           {% with form = Forms.auth.ResetPasswordForm() %}
-            <form method="post" accept-charset="utf-8" autocomplete="off" role="form" class="form-horizontal">
+            <form method="post" accept-charset="utf-8" role="form" class="form-horizontal">
               <p>
                 {% trans %}You can now reset the password for your account and log in. Please enter in a new password below.{% endtrans %}
               </p>


### PR DESCRIPTION
This PR is a small improvement for the input fields on the `login`, `register` and `password_reset` pages.
It signals password managers to use

- `current-password` for login
- `new-password` for register and password_reset

See documentation for the autocomplete attribute here:
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#new-password

> [!WARNING]
> The forms on all three pages currently have `autocomplete="off"`. It is unclear to me why this is the case, but this PR will have no effect as long as autocompletion is turned off at the form level. 

